### PR TITLE
async label dimensions get URI path incorrect

### DIFF
--- a/labeldimensions.go
+++ b/labeldimensions.go
@@ -30,7 +30,7 @@ func (p *PCE) GetLabelDimensions(queryParameters map[string]string) (labelDimens
 	api, err = p.GetCollection("label_dimensions", false, queryParameters, &labelDimensions)
 	if len(labelDimensions) >= 500 {
 		labelDimensions = nil
-		api, err = p.GetCollection("labels", true, queryParameters, &labelDimensions)
+		api, err = p.GetCollection("label_dimensions", true, queryParameters, &labelDimensions)
 	}
 	return labelDimensions, api, err
 }


### PR DESCRIPTION
It is unlikely we will ever hit the actual issue (> 500 label dimensions) but the async URL still had labels instead of label_dimensions and would have returned labels rather than label dimensions data.