### PR TITLE
fix double slash in URLs

### DIFF
--- a/boundaries.go
+++ b/boundaries.go
@@ -37,7 +37,7 @@ func (p *PCE) GetEnforcementBoundaryByHref(href string) (eb EnforcementBoundary,
 
 // CreateEnforcementBoundary creates a new enforcement boundary in the Illumio PCE
 func (p *PCE) CreateEnforcementBoundary(eb EnforcementBoundary) (createdEB EnforcementBoundary, api APIResponse, err error) {
-	api, err = p.Post("/sec_policy/draft/enforcement_boundaries", &eb, &createdEB)
+	api, err = p.Post("sec_policy/draft/enforcement_boundaries", &eb, &createdEB)
 	return createdEB, api, err
 }
 

--- a/iplists.go
+++ b/iplists.go
@@ -46,10 +46,10 @@ func (p *PCE) GetIPLists(queryParameters map[string]string, pStatus string) (ipL
 	if pStatus != "active" && pStatus != "draft" {
 		return ipLists, api, fmt.Errorf("invalid pStatus")
 	}
-	api, err = p.GetCollection("/sec_policy/"+pStatus+"/ip_lists", false, queryParameters, &ipLists)
+	api, err = p.GetCollection("sec_policy/"+pStatus+"/ip_lists", false, queryParameters, &ipLists)
 	if len(ipLists) >= 500 {
 		ipLists = nil
-		api, err = p.GetCollection("/sec_policy/"+pStatus+"/ip_lists", true, queryParameters, &ipLists)
+		api, err = p.GetCollection("sec_policy/"+pStatus+"/ip_lists", true, queryParameters, &ipLists)
 	}
 	return ipLists, api, err
 }

--- a/labelgroups.go
+++ b/labelgroups.go
@@ -43,10 +43,10 @@ func (p *PCE) GetLabelGroups(queryParameters map[string]string, pStatus string) 
 	if pStatus != "active" && pStatus != "draft" {
 		return labelGroups, api, fmt.Errorf("invalid pStatus")
 	}
-	api, err = p.GetCollection("/sec_policy/"+pStatus+"/label_groups", false, queryParameters, &labelGroups)
+	api, err = p.GetCollection("sec_policy/"+pStatus+"/label_groups", false, queryParameters, &labelGroups)
 	if len(labelGroups) >= 500 {
 		labelGroups = nil
-		api, err = p.GetCollection("/sec_policy/"+pStatus+"/label_groups", true, queryParameters, &labelGroups)
+		api, err = p.GetCollection("sec_policy/"+pStatus+"/label_groups", true, queryParameters, &labelGroups)
 	}
 	return labelGroups, api, err
 }

--- a/provisioning.go
+++ b/provisioning.go
@@ -44,7 +44,7 @@ func (p *PCE) ProvisionCS(cs ChangeSubset, comment string) (api APIResponse, err
 	if err != nil {
 		return APIResponse{}, err
 	}
-	api, err = p.Post("/sec_policy", &provision, &struct{}{})
+	api, err = p.Post("sec_policy", &provision, &struct{}{})
 	return api, err
 }
 

--- a/services.go
+++ b/services.go
@@ -56,10 +56,10 @@ func (p *PCE) GetServices(queryParameters map[string]string, pStatus string) (se
 	if pStatus != "active" && pStatus != "draft" {
 		return services, api, fmt.Errorf("invalid pStatus")
 	}
-	api, err = p.GetCollection("/sec_policy/"+pStatus+"/services", false, queryParameters, &services)
+	api, err = p.GetCollection("sec_policy/"+pStatus+"/services", false, queryParameters, &services)
 	if len(services) >= 500 {
 		services = nil
-		api, err = p.GetCollection("/sec_policy/"+pStatus+"/services", true, queryParameters, &services)
+		api, err = p.GetCollection("sec_policy/"+pStatus+"/services", true, queryParameters, &services)
 	}
 	return services, api, err
 }

--- a/virtualserver.go
+++ b/virtualserver.go
@@ -40,10 +40,10 @@ func (p *PCE) GetVirtualServers(queryParameters map[string]string, pStatus strin
 	if pStatus != "active" && pStatus != "draft" {
 		return virtualServers, api, fmt.Errorf("invalid pStatus")
 	}
-	api, err = p.GetCollection("/sec_policy/"+pStatus+"/virtual_servers", false, queryParameters, &virtualServers)
+	api, err = p.GetCollection("sec_policy/"+pStatus+"/virtual_servers", false, queryParameters, &virtualServers)
 	if len(virtualServers) >= 500 {
 		virtualServers = nil
-		api, err = p.GetCollection("/sec_policy/"+pStatus+"/virtual_servers", true, queryParameters, &virtualServers)
+		api, err = p.GetCollection("sec_policy/"+pStatus+"/virtual_servers", true, queryParameters, &virtualServers)
 	}
 	return virtualServers, api, err
 }

--- a/virtualservices.go
+++ b/virtualservices.go
@@ -57,10 +57,10 @@ func (p *PCE) GetVirtualServices(queryParameters map[string]string, pStatus stri
 	if pStatus != "active" && pStatus != "draft" {
 		return virtualServices, api, fmt.Errorf("invalid pStatus")
 	}
-	api, err = p.GetCollection("/sec_policy/"+pStatus+"/virtual_services", false, queryParameters, &virtualServices)
+	api, err = p.GetCollection("sec_policy/"+pStatus+"/virtual_services", false, queryParameters, &virtualServices)
 	if len(virtualServices) >= 500 {
 		virtualServices = nil
-		api, err = p.GetCollection("/sec_policy/"+pStatus+"/virtual_services", true, queryParameters, &virtualServices)
+		api, err = p.GetCollection("sec_policy/"+pStatus+"/virtual_services", true, queryParameters, &virtualServices)
 	}
 	// Populate the map
 	p.VirtualServices = make(map[string]VirtualService)

--- a/workloads.go
+++ b/workloads.go
@@ -251,7 +251,7 @@ func (p *PCE) IncreaseTrafficUpdateRate(wklds []Workload) (APIResponse, error) {
 	inc := IncreaseTrafficUpdateReq{Workloads: t}
 
 	// Run the post. There is no response so just use a any empty struct
-	api, err := p.Post("/workloads/set_flow_reporting_frequency", &inc, &IncreaseTrafficUpdateReq{})
+	api, err := p.Post("workloads/set_flow_reporting_frequency", &inc, &IncreaseTrafficUpdateReq{})
 
 	return api, err
 }


### PR DESCRIPTION
The `GetCollectionHeaders` already has a trailing slash, which lead to a URL with a double slash in it. Even when Illumio seems to tolerate it, our e2e tests complained.
This PR sanitizes the generated URLs.