### PR TITLE
NEN NetworkDevice Endpoint

### DIFF
--- a/networkdevice.go
+++ b/networkdevice.go
@@ -1,6 +1,10 @@
 package illumioapi
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 type NetworkDevice struct {
 	Href                  string `json:"href,omitempty"`
@@ -22,21 +26,83 @@ type NetworkDevice struct {
 	NetworkEnforcementNode                      struct {
 		Href string `json:"href,omitempty"`
 	} `json:"network_enforcement_node,omitempty"`
-	NetworkEndpoints []struct {
-		Href string `json:"href,omitempty"`
-	} `json:"network_endpoints,omitempty"`
+	NetworkEndpoints []NetworkEndpoint
 }
 
-// GetNetworkEnforcementNodes returns a slice of NetworkEnforcementNodes from the PCE.
+type NetworkEndpoint struct {
+	Href   string `json:"href,omitempty"`
+	Config struct {
+		EndpointType      string `json:"endpoint_type,omitempty"`
+		Name              string `json:"name,omitempty"`
+		TrafficFlowID     string `json:"traffic_flow_id,omitempty"`
+		WorkloadDiscovery bool   `json:"workload_discovery,omitempty"`
+	} `json:"config,omitempty"`
+	WorkloadDiscovery bool `json:"workload_discovery,omitempty"`
+	NetworkDevice     struct {
+		Href string `json:"href,omitempty"`
+	} `json:"network_device,omitempty"`
+	Workloads []struct {
+		Href string `json:"href,omitempty"`
+	} `json:"workloads,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type NetDevice struct {
+	Href string `json:"href"`
+}
+
+// NetworkDeviceACLRequest - Data structure for sending a port to the PCE to build ACL.
+type NetworkDeviceACLRequest struct {
+	ListNetworkDevices []NetDevice `json:"network_devices"`
+}
+
+// GetNetworkDeviceSlice returns a slice of NetworkDevices(NEN siwtches) from the PCE as well as the Network Endpoints for each NetworkDevice.
 // queryParameters can be used for filtering in the form of ["parameter"]="value".
-// Not putting async call if greater than 500.
-func (p *PCE) GetNetworkDeviceSlide(queryParameters map[string]string) (api APIResponse, err error) {
+// Currently Not putting async call if greater than 500.
+func (p *PCE) GetNetworkDeviceSlice(queryParameters map[string]string) (api APIResponse, err error) {
 	// Validate pStatus
 
-	api, err = p.GetCollection("network_enforcement_nodes", false, queryParameters, &p.NetworkDeviceSlice)
+	api, err = p.GetCollection("network_devices", false, queryParameters, &p.NetworkDeviceSlice)
 	p.NetworkDevice = make(map[string]NetworkDevice)
-	for _, s := range p.NetworkDeviceSlice {
-		p.NetworkDevice[s.Href] = s
+	if err != nil {
+		return api, err
 	}
+	for index, s := range p.NetworkDeviceSlice {
+		var netendpoint []NetworkEndpoint
+		api, err = p.GetCollection(strings.TrimPrefix(s.Href, fmt.Sprintf("/orgs/%d/", p.Org))+"/network_endpoints", false, map[string]string{}, &netendpoint)
+		if err != nil {
+			return api, err
+		}
+		p.NetworkDeviceSlice[index].NetworkEndpoints = netendpoint
+		p.NetworkDevice[s.Href] = s
+		p.NetworkDevice[s.Config.Name] = s
+	}
+
+	return api, err
+}
+
+// GetNetworkDevice - Get the NetworkDevice data to check if ACL is available
+func (nd *NetworkDevice) GetNetworkDevice(p *PCE, tmpnd *NetworkDevice) (api APIResponse, err error) {
+	// Validate pStatus
+
+	api, err = p.GetHref(nd.Href, &tmpnd)
+	if err != nil {
+		return api, err
+	}
+	return api, err
+}
+
+// RequestNetworkDeviceAcl - will tell the NEN to create a new ACL file/json blob for that
+// Network Device.   You will need to use another call to check if the job has finished.
+func (nd *NetworkDevice) RequestNetworkDeviceACL(p *PCE) (api APIResponse, err error) {
+
+	var requestNd = NetworkDeviceACLRequest{ListNetworkDevices: []NetDevice{{Href: nd.Href}}}
+
+	var tmp interface{}
+	api, err = p.Post("/network_devices/multi_enforcement_instructions_request", requestNd, &tmp)
+	if err != nil {
+		return api, err
+	}
+
 	return api, err
 }

--- a/networkdevice.go
+++ b/networkdevice.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+// NetworkDevice is the data structure for all NEN Switch Objects.
 type NetworkDevice struct {
 	Href                  string `json:"href,omitempty"`
 	SupportedEndpointType string `json:"supported_endpoint_type,omitempty"`
@@ -29,6 +30,7 @@ type NetworkDevice struct {
 	NetworkEndpoints []NetworkEndpoint
 }
 
+// NetworkEndpoint is the data structure for for a NEN Switch object that builds switch ACLs(JSON object too).
 type NetworkEndpoint struct {
 	Href   string `json:"href,omitempty"`
 	Config struct {
@@ -56,7 +58,7 @@ type NetworkDeviceACLRequest struct {
 	ListNetworkDevices []NetDevice `json:"network_devices"`
 }
 
-// GetNetworkDeviceSlice returns a slice of NetworkDevices(NEN siwtches) from the PCE as well as the Network Endpoints for each NetworkDevice.
+// GetNetworkDeviceSlice -returns a slice of NetworkDevices(NEN siwtches) from the PCE as well as the Network Endpoints for each NetworkDevice.
 // queryParameters can be used for filtering in the form of ["parameter"]="value".
 // Currently Not putting async call if greater than 500.
 func (p *PCE) GetNetworkDeviceSlice(queryParameters map[string]string) (api APIResponse, err error) {
@@ -67,6 +69,8 @@ func (p *PCE) GetNetworkDeviceSlice(queryParameters map[string]string) (api APIR
 	if err != nil {
 		return api, err
 	}
+
+	//Cycle through the slide of devices to create a map of the devices using HREF and NAME as keys.
 	for index, s := range p.NetworkDeviceSlice {
 		var netendpoint []NetworkEndpoint
 		api, err = p.GetCollection(strings.TrimPrefix(s.Href, fmt.Sprintf("/orgs/%d/", p.Org))+"/network_endpoints", false, map[string]string{}, &netendpoint)

--- a/networkdevice.go
+++ b/networkdevice.go
@@ -1,0 +1,42 @@
+package illumioapi
+
+import "time"
+
+type NetworkDevice struct {
+	Href                  string `json:"href,omitempty"`
+	SupportedEndpointType string `json:"supported_endpoint_type,omitempty"`
+	Config                struct {
+		DeviceType   string `json:"device_type,omitempty"`
+		Name         string `json:"name,omitempty"`
+		Manufacturer string `json:"manufacturer,omitempty"`
+		Model        string `json:"model,omitempty"`
+		RulesFormat  string `json:"rules_format,omitempty"`
+	} `json:"config,omitempty"`
+	Configure                                   bool      `json:"configure,omitempty"`
+	EnforcementInstructionsDataHref             string    `json:"enforcement_instructions_data_href,omitempty"`
+	EnforcementInstructionsDataTimestamp        time.Time `json:"enforcement_instructions_data_timestamp,omitempty"`
+	EnforcementInstructionsGenerationInProgress bool      `json:"enforcement_instructions_generation_in_progress,omitempty"`
+	EnforcementInstructionsAckHref              string    `json:"enforcement_instructions_ack_href,omitempty"`
+	EnforcementInstructionsAckTimestamp         time.Time `json:"enforcement_instructions_ack_timestamp,omitempty"`
+	Status                                      string    `json:"status,omitempty"`
+	NetworkEnforcementNode                      struct {
+		Href string `json:"href,omitempty"`
+	} `json:"network_enforcement_node,omitempty"`
+	NetworkEndpoints []struct {
+		Href string `json:"href,omitempty"`
+	} `json:"network_endpoints,omitempty"`
+}
+
+// GetNetworkEnforcementNodes returns a slice of NetworkEnforcementNodes from the PCE.
+// queryParameters can be used for filtering in the form of ["parameter"]="value".
+// Not putting async call if greater than 500.
+func (p *PCE) GetNetworkDeviceSlide(queryParameters map[string]string) (api APIResponse, err error) {
+	// Validate pStatus
+
+	api, err = p.GetCollection("network_enforcement_nodes", false, queryParameters, &p.NetworkDeviceSlice)
+	p.NetworkDevice = make(map[string]NetworkDevice)
+	for _, s := range p.NetworkDeviceSlice {
+		p.NetworkDevice[s.Href] = s
+	}
+	return api, err
+}

--- a/pce.go
+++ b/pce.go
@@ -267,7 +267,7 @@ func (p *PCE) loadMulti(l LoadInput) (apiResps map[string]APIResponse, err error
 	if l.NetworkDevice {
 		numAPICalls++
 		go func(p *PCE) {
-			apiResp, err := p.GetNetworkDeviceSlide(nil)
+			apiResp, err := p.GetNetworkDeviceSlice(nil)
 			c <- channelResp{api: apiResp, method: "GetNetworkDeviceSlide", err: err}
 		}(p)
 	}

--- a/pce.go
+++ b/pce.go
@@ -55,6 +55,8 @@ type PCE struct {
 	AuthSecurityPrincipals           map[string]AuthSecurityPrincipal
 	Roles                            map[string]Role
 	RolesSlice                       []Role
+	NetworkDevice                    map[string]NetworkDevice
+	NetworkDeviceSlice               []NetworkDevice
 }
 
 // LoadInput tells the p.Load method what objects to load
@@ -80,6 +82,7 @@ type LoadInput struct {
 	AuthSecurityPrincipals      bool
 	Permissions                 bool
 	Roles                       bool
+	NetworkDevice               bool
 }
 
 // Load gets the objects specified in the LoadInput
@@ -259,6 +262,13 @@ func (p *PCE) loadMulti(l LoadInput) (apiResps map[string]APIResponse, err error
 		go func(p *PCE) {
 			apiResp, err := p.GetRoles(nil)
 			c <- channelResp{api: apiResp, method: "GetRoles", err: err}
+		}(p)
+	}
+	if l.NetworkDevice {
+		numAPICalls++
+		go func(p *PCE) {
+			apiResp, err := p.GetNetworkDeviceSlide(nil)
+			c <- channelResp{api: apiResp, method: "GetNetworkDeviceSlide", err: err}
 		}(p)
 	}
 


### PR DESCRIPTION
NetworkDevice endpoint used to support discovery of NEN switches so that ACL data can be pulled and used.   