### PR TITLE
fix: omitempty on Service.Name so provision references serialize href-only

### DIFF
--- a/services.go
+++ b/services.go
@@ -8,7 +8,7 @@ import (
 // Service represent a service in the PCE
 type Service struct {
 	Href                  string            `json:"href,omitempty"`
-	Name                  string            `json:"name"`
+	Name                  string            `json:"name,omitempty"`
 	Description           string            `json:"description,omitempty"`
 	ProcessName           string            `json:"process_name,omitempty"`
 	ServicePorts          *[]ServicePort    `json:"service_ports,omitempty"`

--- a/services_provision_test.go
+++ b/services_provision_test.go
@@ -1,0 +1,41 @@
+package illumioapi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestServiceProvisionHrefOnly guards against a regression where Service.Name
+// (tagged `json:"name"` without omitempty) forced an empty "name":"" into the
+// provision change_subset. The PCE's POST /sec_policy rejected that with a 406
+// invalid_uri / not_acceptable error, so `delete --provision` of services never
+// committed and objects piled up in a pending-delete draft. A provision
+// reference must serialize href-only: {"href":"..."}.
+func TestServiceProvisionHrefOnly(t *testing.T) {
+	href := "/orgs/1/sec_policy/draft/services/123"
+	b, err := json.Marshal(&Service{Href: href})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	got := string(b)
+	if strings.Contains(got, "\"name\"") {
+		t.Errorf("Service provision reference must not emit a name field; got %s", got)
+	}
+	if got != `{"href":"`+href+`"}` {
+		t.Errorf("expected href-only object, got %s", got)
+	}
+}
+
+// TestServiceNameOmittedWhenEmpty is the narrow unit form of the same fix.
+func TestServiceNameOmittedWhenEmpty(t *testing.T) {
+	b, _ := json.Marshal(&Service{Href: "/orgs/1/services/9"})
+	if strings.Contains(string(b), "name") {
+		t.Errorf("empty Name should be omitted; got %s", string(b))
+	}
+	// A populated name must still serialize (normal create/update path).
+	b2, _ := json.Marshal(&Service{Name: "telnet"})
+	if !strings.Contains(string(b2), `"name":"telnet"`) {
+		t.Errorf("non-empty Name must serialize; got %s", string(b2))
+	}
+}


### PR DESCRIPTION
## Problem
`Service.Name` is tagged `json:"name"` (no `omitempty`), while every other provisionable type — `RuleSet`, `IPList`, `LabelGroup`, `VirtualService`, `VirtualServer`, `EnforcementBoundary` — uses `json:"name,omitempty"`.

`ProvisionHref` builds href-only references:
```go
services = append(services, &Service{Href: h})
```
Because `Name` has no `omitempty`, the unset field serializes into the `change_subset` as `"name":""`. The PCE's `POST /sec_policy` rejects that body:

```
response status code: 406
[{"token":"invalid_uri","message":"Invalid URI: {{\"href\"=>\"/orgs/…/services/…\", \"name\"=>\"\"}}"}]
```

Real-world impact: `workloader delete --provision` of services **never commits** — the deleted services linger in a pending-delete *draft*, and a later `rule-import` then 406s with `Can not assign deleted service`, leaving rulesets empty. (Other types in the same batch provision fine, which is what pointed at `Service` specifically.)

## Fix
Add `omitempty` to `Service.Name`, matching the other provisionable structs. A service provision reference now serializes href-only (`{"href":"..."}`), while a populated `Name` still serializes for the normal create/update path.

## Tests
Adds `services_provision_test.go`:
- `TestServiceProvisionHrefOnly` — `&Service{Href: h}` marshals to exactly `{"href":"..."}` with no `name`.
- `TestServiceNameOmittedWhenEmpty` — empty name omitted; non-empty name still serialized.

Both pass (`go test`), and `go build ./...` is clean.